### PR TITLE
Change YoutubeLoader to YoutubeLoaderDL for supporting add_video_info=True

### DIFF
--- a/rag_from_scratch_10_and_11.ipynb
+++ b/rag_from_scratch_10_and_11.ipynb
@@ -26,7 +26,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "! pip install langchain_community tiktoken langchain-openai langchainhub chromadb langchain youtube-transcript-api pytube"
+    "! pip install langchain_community tiktoken langchain-openai langchainhub chromadb langchain youtube-transcript-api langchain-yt-dlp"
    ]
   },
   {
@@ -451,9 +451,9 @@
     }
    ],
    "source": [
-    "from langchain_community.document_loaders import YoutubeLoader\n",
+    "from langchain_yt_dlp.youtube_loader import YoutubeLoaderDL\n",
     "\n",
-    "docs = YoutubeLoader.from_youtube_url(\n",
+    "docs = YoutubeLoaderDL.from_youtube_url(\n",
     "    \"https://www.youtube.com/watch?v=pbAd8O1Lvm4\", add_video_info=True\n",
     ").load()\n",
     "\n",
@@ -676,7 +676,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "rag-with-langchain",
    "language": "python",
    "name": "python3"
   },
@@ -690,7 +690,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.8"
+   "version": "3.10.13"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
# Summary
Change YoutubeLoader to YoutubeLoaderDL for supporting add_video_info=True in `rag_from_scratch_10_and_11.ipynb`

# Description
Past `YoutubeLoader` class used pytube api. 
After Nov. 2024, youtube required oauth to get metadata. but `YoutubeLoader` class doesn't support pytube's oauth parameter.

So For getting youtube metadata, you use `langchain-yt-dlp` library. this library use yt-dlp package which is getting metadata without oauth process.

## References
https://github.com/langchain-ai/langchain/pull/28775
https://python.langchain.com/docs/integrations/document_loaders/yt_dlp/